### PR TITLE
Patch (temp) AST type initialization

### DIFF
--- a/pkg/yang/ast.go
+++ b/pkg/yang/ast.go
@@ -394,10 +394,12 @@ func initTypes(at reflect.Type) {
 				if v.Type() != at {
 					panic(fmt.Sprintf("given type %s, need type %s", v.Type(), at))
 				}
-				fv := v.Elem().Field(i)
-				if !fv.IsNil() {
-					return errors.New(s.Keyword + ": already set")
-				}
+				// TODO: this currently errors when generating mud.yang.go (base already set)
+				// fv := v.Elem().Field(i)
+				// if !fv.IsNil() {
+				// 	fmt.Println(fv)
+				// 	return errors.New(s.Keyword + ": already set")
+				// }
 
 				// Use build to build the value for this field.
 				sv, err := build(s, v)

--- a/pkg/yang/ast.go
+++ b/pkg/yang/ast.go
@@ -394,12 +394,10 @@ func initTypes(at reflect.Type) {
 				if v.Type() != at {
 					panic(fmt.Sprintf("given type %s, need type %s", v.Type(), at))
 				}
-				// TODO: this currently errors when generating mud.yang.go (base already set)
-				// fv := v.Elem().Field(i)
-				// if !fv.IsNil() {
-				// 	fmt.Println(fv)
-				// 	return errors.New(s.Keyword + ": already set")
-				// }
+				fv := v.Elem().Field(i)
+				if !fv.IsNil() {
+					return errors.New(s.Keyword + ": already set")
+				}
 
 				// Use build to build the value for this field.
 				sv, err := build(s, v)

--- a/pkg/yang/identity.go
+++ b/pkg/yang/identity.go
@@ -168,18 +168,20 @@ func (ms *Modules) resolveIdentities() []error {
 	// that have a base, so that we can do inheritance of these later.
 	for _, i := range identities.dict {
 		if i.Identity.Base != nil {
-			// This identity inherits from another identity.
+			// This identity inherits from one or more other identities.
 
 			root := RootNode(i.Identity)
-			base, baseErr := root.findIdentityBase(i.Identity.Base.asString())
+			for _, b := range i.Identity.Base {
+				base, baseErr := root.findIdentityBase(b.asString())
 
-			if baseErr != nil {
-				errs = append(errs, baseErr...)
-				continue
+				if baseErr != nil {
+					errs = append(errs, baseErr...)
+					continue
+				}
+
+				// Append this value to the children of the base identity.
+				base.Identity.Values = append(base.Identity.Values, i.Identity)
 			}
-
-			// Append this value to the children of the base identity.
-			base.Identity.Values = append(base.Identity.Values, i.Identity)
 		}
 	}
 


### PR DESCRIPTION
When generating `mud.yang.go`, which uses the relatively newly added
support for `if-feature` inside an `identity` structure, the following
error occurs:

`ERROR Generating Code: base: already set`

After some debugging I narrowed the error down to the `if !fv.IsNil()`
statement, but I haven't found a better fix for the issue than to
comment the check out when generating a package for `mud.yang.go` yet.